### PR TITLE
商品詳細実装

### DIFF
--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -145,6 +145,8 @@
   background-color: #fff;
   margin: 5vh 0;
   text-align: center;
+  min-width: 500px;
+  padding: 30px;
 }
 
 .comment-text {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,12 +23,12 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  def edit
-    @item = Items.find(params[:id])
-    unless current_user == @item.user
-      redirect_to root_path
-    end
-  end
+  #def edit
+  #  @item = Items.find(params[:id])
+  #  unless current_user == @item.user
+  #   redirect_to root_path
+  #  end
+  #end
 
   #def update
   #  @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+# 記事の一覧、詳細を確認することができるのはログインユーザーのみ
 
   def index # 一覧表示:降順(DESC)並び替え
     @items = Item.all.order("created_at DESC")
@@ -18,16 +19,16 @@ class ItemsController < ApplicationController
     end
   end
 
-  #def show
-  #  @item = Item.find(params[:id])
-  #end
+  def show
+    @item = Item.find(params[:id])
+  end
 
-  #def edit
-  #  @item = Items.find(params[:id])
-  #  unless current_user == @item.user
-  #    redirect_to root_path
-  #  end
-  #end
+  def edit
+    @item = Items.find(params[:id])
+    unless current_user == @item.user
+      redirect_to root_path
+    end
+  end
 
   #def update
   #  @item = Item.find(params[:id])

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -32,13 +32,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :product, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -51,12 +51,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -72,17 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:deliveryfee_id, Deliveryfee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_id, Shipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -100,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -32,13 +32,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :product, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -51,12 +51,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -72,17 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:deliveryfee_id, Deliveryfee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_id, Shipping.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id), method: :get do %>  <%# 自分の出品物あるなら編集・削除可能画面へ %>
           <div class='image-content'>                                 <%# 画像 %>
           <%= image_tag item.item_image, class: "item-img" %>
 
@@ -163,7 +163,7 @@
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <%= link_to @item_show, method: :get do %>  <%# 自分の出品物ないなら購入画面へ %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -181,10 +181,9 @@
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
-    </ul>
+    <%# /商品一覧 %>
+   <% end %>
   </div>
-  <%# /商品一覧 %>
- <% end %>
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,8 +25,9 @@
   </div>
 
  <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
- 
-  <% if user_signed_in? && current_user.id == @item.user_id %>
+
+  <% if user_signed_in? %>
+   <% if current_user.id == @item.user_id %>
   <%#ユーザーがサインイン済かどうかを判定,サインインしているユーザーを取得する==商品出品者と同じでない場合≡≡> 編集・削除可能 %>
    
     <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
@@ -34,12 +35,12 @@
     <p class='or-text'>or</p>
     <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
    
-   <% elsif user_signed_in? && current_user.id = @item.user_id %>
+   <% else %>
    <%# ログイン者が商品出品者と同じ場合 ==> 購入できない ＝ 閲覧のみ、それ以外は購入できる %>
     <%# 商品が売れていない場合はこちらを表示しましょう %><%# ログイン者の出品商品以外を選択した場合 ==> 購入画面へ%>
     <%= link_to '購入画面に進む', "#", method: :get ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-  
+   <% end %>
   <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,74 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>  
-      <div class='sold-out'>
+      <%#<div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+         <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.deliveryfee.name %>
       </span>
     </div>
+  </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+ <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+ 
+  <% if user_signed_in? && current_user.id == @item.user_id %>
+  <%#ユーザーがサインイン済かどうかを判定,サインインしているユーザーを取得する==商品出品者と同じでない場合≡≡> 編集・削除可能 %>
+   
+    <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+   
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+   
+   <% elsif user_signed_in? && current_user.id = @item.user_id %>
+   <%# ログイン者が商品出品者と同じ場合 ==> 購入できない ＝ 閲覧のみ、それ以外は購入できる %>
+    <%# 商品が売れていない場合はこちらを表示しましょう %><%# ログイン者の出品商品以外を選択した場合 ==> 購入画面へ%>
+    <%= link_to '購入画面に進む', "#", method: :get ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+  
+  <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.deliveryfee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping.name %></td>
         </tr>
       </tbody>
     </table>
@@ -77,8 +85,7 @@
         <span>不適切な商品の通報</span>
       </div>
     </div>
-  </div>
-  <%# /商品の概要 %>
+<%# /商品の概要 %>
 
   <div class="comment-box">
     <form>
@@ -91,6 +98,8 @@
       <button type="submit" class="comment-btn">
         <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
         <span>コメントする<span>
+        </span>
+      </span>
       </button>
     </form>
   </div>
@@ -102,7 +111,8 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
+
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
What
商品詳細作成
Why
商品詳細実装するため

ログイン状態の出品者のみ、「編集・削除ボタン」が表示
https://gyazo.com/dabafbf897f14afb537b11b4d4305b81

ログイン状態の出品者以外（ログアウト）のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/1aca254d73886b6aae20b8b63fdbf9bb


商品出品時に登録した情報が見られるようになっていること
https://gyazo.com/c56b66c4507535916eac70335639cd95


ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できる
＋
ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されない
⇩
「自分が出品した商品は購入できない」という条件分岐を実装
https://gyazo.com/3562073df6c6c0f130ea1a41c935ebe2


ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
https://gyazo.com/9f071c417cd0cab479544b835fd5d71a

